### PR TITLE
Fun

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,9 +3,9 @@
   :url "http://example.com/FIXME"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.6.0"]
+  :dependencies [[org.clojure/clojure "1.7.0"]
                  [clj-http "1.1.2"]
                  [org.clojure/data.json "0.2.6"]]
-  :main ^:skip-aot client.core
+  :main client.core
   :target-path "target/%s"
   :profiles {:uberjar {:aot :all}})

--- a/src/client/core.clj
+++ b/src/client/core.clj
@@ -1,25 +1,46 @@
 (ns client.core
   (:gen-class)
   (:require [clj-http.client :as client]
-            [clojure.data.json :as json]))
+            [clojure.data.json :as json]
+            [clojure.string :as string]))
 
-(defn extractJson
-  [responseBody]
-  (get (json/read-str responseBody) "name"))
-
-(defn makeCall
+(defn get-it
   [url]
-   (:body
-    (client/get url)))
+  (-> url
+    client/get
+    :body
+    json/read-str
+    (get "name")))
 
-(defn getIt
-  [url]
-   (println
-    (extractJson
-     (makeCall url))))
+(defn now [] (System/currentTimeMillis))
+(defn diff-ms [start] (format "%7dms" (- (now) start)))
+
+(defmacro timed-run [title & body]
+  `(let [start# (now)]
+     (println ~title "starting...")
+     ~@body
+     (println ~title "completed in" (diff-ms start#))))
 
 (defn -main []
-  (loop [i 0]
-    (when (< i 100)
-      (getIt "http://localhost:9292")
-      (recur (inc i)))))
+  (let [main-start (now) n   100
+        url "http://localhost:9292"]
+    
+    (timed-run "Serial"
+      (println (string/join "\n"
+                 (take n (repeatedly #(get-it url))))))
+
+    (timed-run "Parallel"
+      (println (string/join "\n"
+                 (pmap identity (take n (repeatedly #(get-it url)))))))
+
+    (timed-run "Serial w/o print"
+      ;; clojure is lazy, so if we don't print these,
+      ;; the work may not be done; doall ensures it is
+      (doall (take n (repeatedly #(get-it url)))))
+
+    (timed-run "Parallel w/o print"
+      (doall (pmap identity (take n (repeatedly #(get-it url))))))
+
+    ;;we used pmap, so background agent threads will wait
+    ;; until timeout (30s?) on exit; this terminates them now
+    (shutdown-agents)))

--- a/src/client/core.clj
+++ b/src/client/core.clj
@@ -22,25 +22,26 @@
      (println ~title "completed in" (diff-ms start#))))
 
 (defn -main []
-  (let [main-start (now) n   100
-        url "http://localhost:9292"]
-    
-    (timed-run "Serial"
-      (println (string/join "\n"
-                 (take n (repeatedly #(get-it url))))))
+  (timed-run "TOTAL"
+    (let [n 100
+          url "http://localhost:9292"]
 
-    (timed-run "Parallel"
-      (println (string/join "\n"
-                 (pmap identity (take n (repeatedly #(get-it url)))))))
+      (timed-run "Serial"
+        (println (string/join "\n"
+                   (take n (repeatedly #(get-it url))))))
 
-    (timed-run "Serial w/o print"
-      ;; clojure is lazy, so if we don't print these,
-      ;; the work may not be done; doall ensures it is
-      (doall (take n (repeatedly #(get-it url)))))
+      (timed-run "Parallel"
+        (println (string/join "\n"
+                   (pmap identity (take n (repeatedly #(get-it url)))))))
 
-    (timed-run "Parallel w/o print"
-      (doall (pmap identity (take n (repeatedly #(get-it url))))))
+      (timed-run "Serial w/o print"
+        ;; clojure is lazy, so if we don't print these,
+        ;; the work may not be done; doall ensures it is
+        (doall (take n (repeatedly #(get-it url)))))
 
-    ;;we used pmap, so background agent threads will wait
-    ;; until timeout (30s?) on exit; this terminates them now
-    (shutdown-agents)))
+      (timed-run "Parallel w/o print"
+        (doall (pmap identity (take n (repeatedly #(get-it url))))))
+
+      ;;we used pmap, so background agent threads will wait
+      ;; until timeout (30s?) on exit; this terminates them now
+      (shutdown-agents))))


### PR DESCRIPTION
This may be slightly more idiomatic Clojure.
- since your functions were mostly wrapping existing functions, I used the threading (-> ...) macro for the pipeline of work
- get-it is more lispy/clojure-y than getIt
- necessity for loop is rare, so (take n (repeatedly #(get-it ...))) wins
- map and pmap (parallel execution) runs

I never really run Clojure in a one-off script way in production, so the JVM start up time could arguably not be part of the benchmark.  But, I suppose it's a fair comparison if used in that way.
